### PR TITLE
Add Token-based Authorization Option

### DIFF
--- a/src/remote-introspection.js
+++ b/src/remote-introspection.js
@@ -3,10 +3,14 @@ const formEncode = require('form-urlencoded');
 const errors = require('./errors');
 
 module.exports = (options) => {
+  const authorization = options.access_token ? 
+    `Bearer ${options.access_token}` : 
+    `Basic ${Buffer.from(`${options.client_id}:${options.client_secret}`).toString('base64')}`;
+    
   const fetchOption = {
     method: 'POST',
     headers: {
-      Authorization: `Basic ${Buffer.from(`${options.client_id}:${options.client_secret}`).toString('base64')}`,
+      Authorization: authorization,
       'Content-Type': 'application/x-www-form-urlencoded',
       'User-Agent': options.user_agent,
     },

--- a/test/introspection.test.js
+++ b/test/introspection.test.js
@@ -25,7 +25,7 @@ describe('Configuration', () => {
 });
 
 describe('Remote token introspection', () => {
-  it('calls fetch with correct parameters', () => {
+  it('calls fetch with correct parameters for client-based authentication', () => {
     const introspection = new TokenIntrospection({
       endpoint: 'http://example.com/oauth/introspection',
       client_id: 'client',
@@ -34,6 +34,26 @@ describe('Remote token introspection', () => {
         assert.equal(url, 'http://example.com/oauth/introspection');
         assert.equal(opts.method, 'POST');
         assert.equal(opts.headers.Authorization, 'Basic Y2xpZW50OnNlY3JldA==');
+        assert.equal(opts.headers['Content-Type'], 'application/x-www-form-urlencoded');
+        assert.equal(opts.body, 'token=token&token_type_hint=access_token');
+        assert.isNull(opts.agent);
+        return {
+          ok: true,
+          json: () => Promise.resolve({ active: true }),
+        };
+      },
+    });
+    return expect(introspection('token', 'access_token')).to.eventually.deep.equal({ active: true });
+  });
+
+  it('calls fetch with correct parameters for token-based authentication', () => {
+    const introspection = new TokenIntrospection({
+      endpoint: 'http://example.com/oauth/introspection',
+      access_token: 'test1234',
+      async fetch(url, opts) {
+        assert.equal(url, 'http://example.com/oauth/introspection');
+        assert.equal(opts.method, 'POST');
+        assert.equal(opts.headers.Authorization, 'Bearer test1234');
         assert.equal(opts.headers['Content-Type'], 'application/x-www-form-urlencoded');
         assert.equal(opts.body, 'token=token&token_type_hint=access_token');
         assert.isNull(opts.agent);


### PR DESCRIPTION
RFC7662 specifies that you MUST use authentication for an introspection
request, but it doesn't specify that it must be client-based:

> To prevent token scanning attacks, the endpoint MUST also require
> some form of authorization to access this endpoint, such as client
> authentication as described in OAuth 2.0 [RFC6749] or a separate
> OAuth 2.0 access token such as the bearer token described in OAuth
> 2.0 Bearer Token Usage [RFC6750].  The methods of managing and
> validating these authentication credentials are out of scope of this
> specification.

Our OAuth server does a BCrypt hash for client-based authorization (and
any OAuth server should do some type of expensive operation on the
client secret) and so it also supports client tokens for an
introspection request.

This PR adds support for these in addition to client ID/secret
authorization.