### PR TITLE
Allow true string value for active prop in introspection response

### DIFF
--- a/src/remote-introspection.js
+++ b/src/remote-introspection.js
@@ -39,7 +39,7 @@ module.exports = (options) => {
     }
 
     const tokenData = await res.json();
-    if (tokenData.active === true) {
+    if (tokenData.active === true || tokenData.active === 'true') {
       return tokenData;
     }
 

--- a/test/introspection.test.js
+++ b/test/introspection.test.js
@@ -97,6 +97,21 @@ describe('Remote token introspection', () => {
     });
     return expect(introspection('token', 'access_token')).to.be.rejectedWith(Error, 'Token is not active');
   });
+
+  it('accept token with active: "true" (string type)', () => {
+    const introspection = new TokenIntrospection({
+      endpoint: 'http://example.com/oauth/introspection',
+      client_id: 'client',
+      client_secret: 'secret',
+      async fetch() {
+        return {
+          ok: true,
+          json: () => Promise.resolve({ active: 'true' }),
+        };
+      },
+    });
+    return expect(introspection('token', 'access_token')).to.eventually.deep.equal({ active: 'true' });
+  });
 });
 
 describe('Local token introspection with static JWKS', () => {


### PR DESCRIPTION
Ran into an issue where an authorization server provides a _string_ value for `active` in the introspection response, and if I follow the doc right for [RFC 7662, section 2.2](https://tools.ietf.org/html/rfc7662#section-2.2), I believe `active === 'true'` should work in addition to a strict boolean type (`active === true`).