### PR TITLE
Update form-urlencoded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
-        "form-urlencoded": "^4.1.3",
+        "form-urlencoded": "^6.0.0",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.2",
         "pem-jwk": "^2.0.0"
@@ -574,7 +574,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1249,9 +1248,9 @@
       "dev": true
     },
     "node_modules/form-urlencoded": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.4.2.tgz",
-      "integrity": "sha512-6sZj0HI9tCcGuzC9W/nkHvNLAjOo1G/jjnNluChOGMwn75Po6g5nGYASxQUJeSQHLng1SpovGjQr1f4xz1PqQw=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.0.0.tgz",
+      "integrity": "sha512-X8AvXpvwMZwbd3/qIegrkZLzPos6djGYaL0bm2nVREzEB/05csjKmdAPTDZMGcFYfVtV9hx5kbpo5Ze87n3HWA=="
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -4213,9 +4212,9 @@
       "dev": true
     },
     "form-urlencoded": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-4.4.2.tgz",
-      "integrity": "sha512-6sZj0HI9tCcGuzC9W/nkHvNLAjOo1G/jjnNluChOGMwn75Po6g5nGYASxQUJeSQHLng1SpovGjQr1f4xz1PqQw=="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/form-urlencoded/-/form-urlencoded-6.0.0.tgz",
+      "integrity": "sha512-X8AvXpvwMZwbd3/qIegrkZLzPos6djGYaL0bm2nVREzEB/05csjKmdAPTDZMGcFYfVtV9hx5kbpo5Ze87n3HWA=="
     },
     "fs.realpath": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/schibsted/node-token-introspection#readme",
   "dependencies": {
     "debug": "^4.1.1",
-    "form-urlencoded": "^4.1.3",
+    "form-urlencoded": "^6.0.0",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^2.0.2",
     "pem-jwk": "^2.0.0"

--- a/src/remote-introspection.js
+++ b/src/remote-introspection.js
@@ -1,5 +1,5 @@
 const debug = require('debug')('token-introspection');
-const formEncode = require('form-urlencoded').default;
+const formEncode = require('form-urlencoded');
 const errors = require('./errors');
 
 module.exports = (options) => {


### PR DESCRIPTION
This updates form-urlencoded to 6.0.0. The new version now optimized the ESM module importing which means `.default` is not necessary anymore to use as per the README.