### PR TITLE
fix: use provided fetcher to fetch jwks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,24 @@ tokenIntrospection(token).then(console.log).catch(console.warn);
 
 ## Configuration
 
-| Field                     | Required | Comment |
-| ------------------------- | :------: | ------- |
-| jwks                      | (X)      | Static JWKS of trusted keys, for example `{keys: [{kty:'RSA',n:'4-4mhUVhY2k',e:'AQAB'}]}` |
-| jwks_uri                  | (X)      | URL of a trusted JWKS, for example `https://example.com/jwks` |
-| endpoint                  | (X)      | URL to call, for instance https://example.com/introspect |
-| allowed_algs              |          | List of allowed signing algorithms, defaults to `['RS256']` |
-| jwks_cache_enabled        |          | If jwks response should be cached, defaults to true |
-| jwks_cache_maxentries     |          | How many jwk's to cache, defaults to 10 |
-| jwks_cache_time           |          | How long a jwk is cached, in ms, defaults to 5 min |
-| jwks_timeout              |          | Timeout in ms for fetching jwks, defaults to 10s |
-| jwks_ratelimit_enabled    |          | If ratelimit of calls to jwks endpoint, defaults to true |
-| jwks_ratelimit_per_minute |          | Limits of jwks calls, defaults to 60 rpm |
-| client_id                 |          | Client ID used to introspect |
-| client_secret             |          | Client secret used to introspect |
-| access_token              |          | Access token used to introspect, instead of client credentials |
-| user_agent                |          | Defaults to `token-introspection` |
-| fetch                     |          | Defaults to [node-fetch](https://github.com/bitinn/node-fetch), but you can inject [zipkin-instrumentation-fetch](https://www.npmjs.com/package/zipkin-instrumentation-fetch). |
+| Field                     | Required | Comment                                                                                                                                                                                                                |
+| ------------------------- | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| jwks                      |   (X)    | Static JWKS of trusted keys, for example `{keys: [{kty:'RSA',n:'4-4mhUVhY2k',e:'AQAB'}]}`                                                                                                                              |
+| jwks_uri                  |   (X)    | URL of a trusted JWKS, for example `https://example.com/jwks`                                                                                                                                                          |
+| endpoint                  |   (X)    | URL to call, for instance https://example.com/introspect                                                                                                                                                               |
+| allowed_algs              |          | List of allowed signing algorithms, defaults to `['RS256']`                                                                                                                                                            |
+| jwks_cache_enabled        |          | If jwks response should be cached, defaults to true                                                                                                                                                                    |
+| jwks_cache_maxentries     |          | How many jwk's to cache, defaults to 10                                                                                                                                                                                |
+| jwks_cache_time           |          | How long a jwk is cached, in ms, defaults to 5 min                                                                                                                                                                     |
+| jwks_timeout              |          | Timeout in ms for fetching jwks, defaults to 10s                                                                                                                                                                       |
+| jwks_ratelimit_enabled    |          | If ratelimit of calls to jwks endpoint, defaults to true                                                                                                                                                               |
+| jwks_ratelimit_per_minute |          | Limits of jwks calls, defaults to 60 rpm                                                                                                                                                                               |
+| jwks_client_fetcher       |          | Fetcher function that is used by the [Jwks Client library](https://www.npmjs.com/package/jwks-rsa). It must resolve to the Jwks response. Some `jwks_*` options do not apply when using the custom jwks client fetcher |
+| client_id                 |          | Client ID used to introspect                                                                                                                                                                                           |
+| client_secret             |          | Client secret used to introspect                                                                                                                                                                                       |
+| access_token              |          | Access token used to introspect, instead of client credentials                                                                                                                                                         |
+| user_agent                |          | Defaults to `token-introspection`                                                                                                                                                                                      |
+| fetch                     |          | Defaults to [node-fetch](https://github.com/bitinn/node-fetch), but you can inject [zipkin-instrumentation-fetch](https://www.npmjs.com/package/zipkin-instrumentation-fetch).                                         |
 
 At least one of the required configuration parameters `jwks`, `jwks_uri` or `endpoint` must be specified.
 

--- a/README.md
+++ b/README.md
@@ -32,24 +32,24 @@ tokenIntrospection(token).then(console.log).catch(console.warn);
 
 ## Configuration
 
-| Field                     | Required | Comment                                                                                                                                                                                                                |
-| ------------------------- | :------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| jwks                      |   (X)    | Static JWKS of trusted keys, for example `{keys: [{kty:'RSA',n:'4-4mhUVhY2k',e:'AQAB'}]}`                                                                                                                              |
-| jwks_uri                  |   (X)    | URL of a trusted JWKS, for example `https://example.com/jwks`                                                                                                                                                          |
-| endpoint                  |   (X)    | URL to call, for instance https://example.com/introspect                                                                                                                                                               |
-| allowed_algs              |          | List of allowed signing algorithms, defaults to `['RS256']`                                                                                                                                                            |
-| jwks_cache_enabled        |          | If jwks response should be cached, defaults to true                                                                                                                                                                    |
-| jwks_cache_maxentries     |          | How many jwk's to cache, defaults to 10                                                                                                                                                                                |
-| jwks_cache_time           |          | How long a jwk is cached, in ms, defaults to 5 min                                                                                                                                                                     |
-| jwks_timeout              |          | Timeout in ms for fetching jwks, defaults to 10s                                                                                                                                                                       |
-| jwks_ratelimit_enabled    |          | If ratelimit of calls to jwks endpoint, defaults to true                                                                                                                                                               |
-| jwks_ratelimit_per_minute |          | Limits of jwks calls, defaults to 60 rpm                                                                                                                                                                               |
+| Field                     | Required | Comment |
+| ------------------------- | :------: | ------- |
+| jwks                      | (X)      | Static JWKS of trusted keys, for example `{keys: [{kty:'RSA',n:'4-4mhUVhY2k',e:'AQAB'}]}` |
+| jwks_uri                  | (X)      | URL of a trusted JWKS, for example `https://example.com/jwks` |
+| endpoint                  | (X)      | URL to call, for instance https://example.com/introspect |
+| allowed_algs              |          | List of allowed signing algorithms, defaults to `['RS256']` |
+| jwks_cache_enabled        |          | If jwks response should be cached, defaults to true |
+| jwks_cache_maxentries     |          | How many jwk's to cache, defaults to 10 |
+| jwks_cache_time           |          | How long a jwk is cached, in ms, defaults to 5 min |
+| jwks_timeout              |          | Timeout in ms for fetching jwks, defaults to 10s |
+| jwks_ratelimit_enabled    |          | If ratelimit of calls to jwks endpoint, defaults to true |
+| jwks_ratelimit_per_minute |          | Limits of jwks calls, defaults to 60 rpm |
 | jwks_client_fetcher       |          | Fetcher function that is used by the [Jwks Client library](https://www.npmjs.com/package/jwks-rsa). It must resolve to the Jwks response. Some `jwks_*` options do not apply when using the custom jwks client fetcher |
-| client_id                 |          | Client ID used to introspect                                                                                                                                                                                           |
-| client_secret             |          | Client secret used to introspect                                                                                                                                                                                       |
-| access_token              |          | Access token used to introspect, instead of client credentials                                                                                                                                                         |
-| user_agent                |          | Defaults to `token-introspection`                                                                                                                                                                                      |
-| fetch                     |          | Defaults to [node-fetch](https://github.com/bitinn/node-fetch), but you can inject [zipkin-instrumentation-fetch](https://www.npmjs.com/package/zipkin-instrumentation-fetch).                                         |
+| client_id                 |          | Client ID used to introspect |
+| client_secret             |          | Client secret used to introspect |
+| access_token              |          | Access token used to introspect, instead of client credentials |
+| user_agent                |          | Defaults to `token-introspection` |
+| fetch                     |          | Defaults to [node-fetch](https://github.com/bitinn/node-fetch), but you can inject [zipkin-instrumentation-fetch](https://www.npmjs.com/package/zipkin-instrumentation-fetch). |
 
 At least one of the required configuration parameters `jwks`, `jwks_uri` or `endpoint` must be specified.
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ function tokenIntrospect(opts = {}) {
   const defaults = {
     jwks: null,
     jwks_uri: '',
+    jwks_client_fetcher: null,
     endpoint: '',
     allowed_algs: ['RS256'],
     client_id: '',

--- a/src/local-introspection.js
+++ b/src/local-introspection.js
@@ -32,7 +32,11 @@ module.exports = (options) => {
       rateLimit: options.jwks_ratelimit_enabled || true,
       jwksRequestsPerMinute: options.jwks_ratelimit_per_minute || 60, // 1 rps
       jwksUri: options.jwks_uri,
-      fetcher: options.fetch && ((url) => options.fetch(url).then(res => res.ok ? res.json() : Promise.reject(new Error(res.statusText)))),
+      fetcher: options.fetch && (
+        (url) => options.fetch(url).then(
+          (res) => (res.ok ? res.json() : Promise.reject(new Error(res.statusText))),
+        )
+      ),
     });
   }
 

--- a/src/local-introspection.js
+++ b/src/local-introspection.js
@@ -32,11 +32,7 @@ module.exports = (options) => {
       rateLimit: options.jwks_ratelimit_enabled || true,
       jwksRequestsPerMinute: options.jwks_ratelimit_per_minute || 60, // 1 rps
       jwksUri: options.jwks_uri,
-      fetcher: options.fetch && (
-        (url) => options.fetch(url).then(
-          (res) => (res.ok ? res.json() : Promise.reject(new Error(res.statusText))),
-        )
-      ),
+      fetcher: options.jwks_client_fetcher,
     });
   }
 

--- a/src/local-introspection.js
+++ b/src/local-introspection.js
@@ -32,6 +32,7 @@ module.exports = (options) => {
       rateLimit: options.jwks_ratelimit_enabled || true,
       jwksRequestsPerMinute: options.jwks_ratelimit_per_minute || 60, // 1 rps
       jwksUri: options.jwks_uri,
+      fetcher: options.fetch && ((url) => options.fetch(url).then(res => res.ok ? res.json() : Promise.reject(new Error(res.statusText)))),
     });
   }
 

--- a/test/introspection.test.js
+++ b/test/introspection.test.js
@@ -143,17 +143,20 @@ describe('Local token introspection with static JWKS', () => {
 
 describe('Fallback order for introspection methods: local introspection with static JWKS -> local introspection with remote JWKS -> remote introspection', () => {
   it('falls back to remote introspection if the verification with static JWKS and remote JWKS fails', () => {
-    nock('http://example.com')
-      .get('/jwks')
-      .reply(200, { keys: [] }); // no keys
-
     const introspection = new TokenIntrospection({
       jwks: {}, // no keys
       jwks_uri: jwksUri,
       endpoint: 'http://example.com/oauth/introspection',
       client_id: 'client',
       client_secret: 'secret',
-      async fetch() {
+      async fetch(url) {
+        if (url === jwksUri) {
+          return {
+            ok: true,
+            json: () => Promise.resolve({ keys: [] }), // no keys
+          };
+        }
+
         return {
           ok: true,
           json: () => Promise.resolve({ active: true }),

--- a/test/introspection.test.js
+++ b/test/introspection.test.js
@@ -125,11 +125,14 @@ describe('Local token introspection with static JWKS', () => {
   it('does local introspection with remote keys if JWKS uri is specified', () => {
     const introspection = new TokenIntrospection({
       jwks_uri: jwksUri,
-      fetch: () => { throw new Error('should not be called'); },
+      async fetch(url) {
+        assert.equal(url, jwksUri);
+        return {
+          ok: true,
+          json: () => Promise.resolve(jwks),
+        };
+      },
     });
-    nock('http://example.com')
-      .get('/jwks')
-      .reply(200, jwks);
 
     const now = Date.now() / 1000;
     const accessTokenClaims = { exp: now + 5 };

--- a/test/introspection.test.js
+++ b/test/introspection.test.js
@@ -125,6 +125,7 @@ describe('Local token introspection with static JWKS', () => {
   it('does local introspection with remote keys if JWKS uri is specified', () => {
     const introspection = new TokenIntrospection({
       jwks_uri: jwksUri,
+      fetch: () => { throw new Error('should not be called'); },
       async jwks_client_fetcher(url) {
         assert.equal(url, jwksUri);
         return jwks;


### PR DESCRIPTION
I had to do some magic tricks to keep the fetcher's interface the same because JwksClient expects to just return the jwks.

This PR is more for a discussion, maybe we should use a different fetch implementation for this purpose. I've checked it and JwksClient uses node http or https agent.